### PR TITLE
Expose the created HTTP server to allow use in combination with other…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,9 @@ ServeMe.prototype = {
     }
   },
 
+  httpServer: function() {
+    return this.server.server;
+  },
 
   //Session
   Session: ServeMe.Session = Sessions,

--- a/test/serveme_tests.js
+++ b/test/serveme_tests.js
@@ -31,6 +31,11 @@ describe('ServeMe HttpServer', function() {
     done();
   });
 
+  it('is exposed via httpServer', function(done) {
+    expect(server.httpServer()).to.equal(server.server.server);
+    done();
+  });
+
   after(function() {
     server.stop();
   });
@@ -111,7 +116,7 @@ describe('ServeMe Routes', function() {
 
     expect(server.routes.take("GET", "/api/user").callbacks[0]).to.be(callback);
     expect(server.routes.take("GET", "/api/user").fails[0]).to.be(fail);
-    
+
     done();
   });
 
@@ -148,7 +153,7 @@ describe('ServeMe Routes', function() {
 
   it('can success a require in a route', function(done) {
     server.reset();
-    
+
     var callback = function() { return "added a success route"; };
 
     var fail = function() { return ""; };


### PR DESCRIPTION
… libraries e.g. WebSockets

Love the library, nice and simple, perfect for some quick prototyping.

My use case is to use websockets and serve up a basic test client from the same host, so need the HTTPServer exposed.

This is available via ServeMe.server.server, but that isn't the prettiest, so this PR is to expose the HTTPServer via a simple httpServer getter (and add a basic test)

Using the OpenShift ws example with ServeMe:

    var ServeMe, WebSocketServer, http, ipaddress, port, wss;

    ServeMe = require('serve-me')();

    ipaddress = process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1';
    port = process.env.OPENSHIFT_NODEJS_PORT || 8080;

    ServeMe.start(port);

    WebSocketServer = require('ws').Server;
    http = require('http');

    wss = new WebSocketServer({
      server: ServeMe.httpServer(),
      autoAcceptConnections: false
    });

    wss.on('connection', function(ws) {
      console.log('New connection');
      ws.on('message', function(message) {
        ws.send('Received: ' + message);
      });
      ws.send('Welcome!');
    });

    console.log('Listening to ' + ipaddress + ':' + port + '...');

Testing the websockets via wscat

     wscat -c 127.0.0.1:8080

    connected (press CTRL+C to quit)

    < Welcome!
    >

and static file serving via http

    curl http://127.0.0.1:8080

    <!DOCTYPE html>
    <html lang="en">
      <head>
        <meta charset="utf-8">
        <title>Test page</title>
      </head>
      <body>
        <h1>TODO: this</h1>
      </body>
    </html>

Produces:

    Listening to 127.0.0.1:8080...
    >> ServeMe v0.8.2
    ----------
    >> Listening at port:   8080
    >> Secure mode(https) disabled
    >> Debug mode         disabled
    New connection

    >> Serving (GET)/ to ::ffff:127.0.0.1
    >>   Served file from disk.