### PR TITLE
adds mjs MIME type support

### DIFF
--- a/lib/mime.js
+++ b/lib/mime.js
@@ -89,6 +89,7 @@ var mime = {
     'isp':   'application/x-internet-signup',
     'iii':   'application/x-iphone',
     'js':    'application/x-javascript',
+    'mjs':    'application/x-javascript',
     'latex': 'application/x-latex',
     'mdb':   'application/x-msaccess',
     'crd':   'application/x-mscardfile',

--- a/lib/mime.js
+++ b/lib/mime.js
@@ -89,7 +89,7 @@ var mime = {
     'isp':   'application/x-internet-signup',
     'iii':   'application/x-iphone',
     'js':    'application/x-javascript',
-    'mjs':    'application/x-javascript',
+    'mjs':   'application/x-javascript',
     'latex': 'application/x-latex',
     'mdb':   'application/x-msaccess',
     'crd':   'application/x-mscardfile',


### PR DESCRIPTION
This allows Javascript modules to be served to browsers. For more info see: 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules

"To get modules to work correctly in a browser, you need to make sure that your server is serving them with a Content-Type header that contains a JavaScript MIME type such as text/javascript. If you don't, you'll get a strict MIME type checking error along the lines of "The server responded with a non-JavaScript MIME type" and the browser won't run your JavaScript. Most servers already set the correct type for .js files, but not yet for .mjs files. Servers that already serve .mjs files correctly include GitHub Pages and http-server for Node.js."